### PR TITLE
Added functions for each addressing mode and fixed all the functions/…

### DIFF
--- a/6502include/cpu.hpp
+++ b/6502include/cpu.hpp
@@ -64,11 +64,17 @@ struct CPU {
     void LDAStatusUpdate();
     void LDXStatusUpdate();
 
-    // Get zero page address Y
-    Byte GetZeroPageAddrY(unsigned int& nCycles, Mem &mem);
-    Byte GetZeroPageAddrX(unsigned int& nCycles, Mem &mem);
-    Word GetAddrY(unsigned int &nCycles, Mem &mem);
-    Word GetAddrX(unsigned int &nCycles, Mem &mem);
+    // Addressing modes
+    Byte AddressingZeroPage(unsigned int &nCycles, Mem &mem);
+    Byte AddressingZeroPageX(unsigned int &nCycles, Mem &mem);
+    Byte AddressingZeroPageY(unsigned int &nCycles, Mem &mem);
+    Byte AddressingRelative(unsigned int &nCycles, Mem &mem);
+    Word AddressingAbsolute(unsigned int &nCycles, Mem &mem);
+    Word AddressingAbsoluteX(unsigned int &nCycles, Mem &mem);
+    Word AddressingAbsoluteY(unsigned int &nCycles, Mem &mem);
+    Word AddressingIndirect(unsigned int &nCycles, Mem &mem);
+    Word AddressingIndexedIndirect(unsigned int &nCycles, Mem &mem);
+    Word AddressingIndirectIndexed(unsigned int &nCycles, Mem &mem);
 
     /*
      * Immediate: load next byte as the "argument" to the instruction.

--- a/6502test/loadregistertests.cpp
+++ b/6502test/loadregistertests.cpp
@@ -154,14 +154,18 @@ TEST_F(LoadRegisterTest, TestLDAAbsoluteY) {
 }
 
 TEST_F(LoadRegisterTest, TestLDAIndirectX) {
-    cpu.X = 0x5;
-    mem[0x0000] = cpu.INS_LDA_IDX;
-    mem[0x0001] = 0x41;
+    cpu.X = 0x04;
+	mem[0x0000] = cpu.INS_LDA_IDX;
+	mem[0x0001] = 0x02;
 
-    mem[0x46] = 0x42;
+	mem[0x0006] = 0x00;	//0x2 + 0x4
+	mem[0x0007] = 0x80;	
+	mem[0x8000] = 0x37;
 
-    cpu.Execute(5, mem);
-    EXPECT_EQ(cpu.A, 0x42);
+    cpu.Execute(6, mem);
+    
+    EXPECT_EQ(cpu.A, 0x37);
+
     EXPECT_FALSE(cpu.C);
     EXPECT_FALSE(cpu.Z);
     EXPECT_FALSE(cpu.I);
@@ -172,14 +176,18 @@ TEST_F(LoadRegisterTest, TestLDAIndirectX) {
 }
 
 TEST_F(LoadRegisterTest, TestLDAIndirectY) {
-    cpu.Y = 0x5;
-    mem[0x0000] = cpu.INS_LDA_IDY;
-    mem[0x0001] = 0x41;
+    cpu.Y = 0x04;
+	mem[0x0000] = cpu.INS_LDA_IDY;
+	mem[0x0001] = 0x02;
 
-    mem[0x46] = 0x42;
+	mem[0x0006] = 0x00;	//0x2 + 0x4
+	mem[0x0007] = 0x80;	
+	mem[0x8000] = 0x37;
 
-    cpu.Execute(5, mem);
-    EXPECT_EQ(cpu.A, 0x42);
+    cpu.Execute(6, mem);
+    
+    EXPECT_EQ(cpu.A, 0x37);
+
     EXPECT_FALSE(cpu.C);
     EXPECT_FALSE(cpu.Z);
     EXPECT_FALSE(cpu.I);

--- a/6502test/memoryinstructiontests.cpp
+++ b/6502test/memoryinstructiontests.cpp
@@ -90,27 +90,31 @@ TEST_F(MemoryInstructionTests, TestSTAAbsoluteY){
 }
 
 TEST_F(MemoryInstructionTests, TestSTAIndirectX) {
-    cpu.A = 0x69;
-    cpu.X = 0x01;
+    cpu.X = 0x04;
+    cpu.A = 0x42;
+	mem[0x0000] = cpu.INS_STA_IDX;
+	mem[0x0001] = 0x02;
 
-    mem[0x0000] = cpu.INS_STA_IDX;
-    mem[0x0001] = 0x41;
+	mem[0x0006] = 0x00;	//0x2 + 0x4
+	mem[0x0007] = 0x80;	
 
     cpu.Execute(6, mem);
-
-    EXPECT_EQ(mem[0x42], 0x69);
+    
+    EXPECT_EQ(mem[0x8000], 0x42);
 }
 
 TEST_F(MemoryInstructionTests, TestSTAIndirectY) {
-    cpu.A = 0x69;
-    cpu.Y = 0x01;
+    cpu.Y = 0x04;
+    cpu.A = 0x42;
+	mem[0x0000] = cpu.INS_STA_IDY;
+	mem[0x0001] = 0x02;
 
-    mem[0x0000] = cpu.INS_STA_IDY;
-    mem[0x0001] = 0x41;
+	mem[0x0006] = 0x00;	//0x2 + 0x4
+	mem[0x0007] = 0x80;	
 
     cpu.Execute(6, mem);
-
-    EXPECT_EQ(mem[0x42], 0x69);
+    
+    EXPECT_EQ(mem[0x8000], 0x42);
 }
 
 TEST_F(MemoryInstructionTests, TestSTXZeroPage) {


### PR DESCRIPTION
…tests with indexed indirect/indirect indexed addressing modes. Fixed #19 and #17 . We're not going to include implicit (for obvious reasons), immediate (becuase it specifies a value not an address), and relative (becuase we're going to only  use that for branching instrucitons, which can be handled by that function) for the fix to #17 